### PR TITLE
feat: Add python-tkinter

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -57,6 +57,7 @@
 				"printer-driver-brlaser",
 				"ptyxis",
 				"pulseaudio-utils",
+				"python-tkinter",
 				"python3-pip",
 				"rclone",
 				"restic",


### PR DESCRIPTION
Allows python apps to use import tkinter to run GUI python apps.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
